### PR TITLE
Ensure compatibility with Laravel 5.6 & lower.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,10 +25,8 @@ class ServiceProvider extends LaravelServiceProvider
             return new Client(config('msg91.auth_key'));
         });
         $this->app->alias(Client::class, 'msg91');
-        Notification::resolved(function (ChannelManager $service) {
-            $service->extend('msg91', function () {
-                return new Channels\Msg91Channel(app(Client::class));
-            });
+        Notification::extend('msg91', function () {
+            return new Channels\Msg91Channel(app(Client::class));
         });
     }
 


### PR DESCRIPTION
The `Notification::resolved` register tries to load `mail` channel as well which throws error `Class mailer not found` while composer runs `package:discover` after installing the pacakge on laravel/laravel 5.6 or earlier.